### PR TITLE
(feat) add custom build args

### DIFF
--- a/symfony/5.2-apache-onbuild/Dockerfile
+++ b/symfony/5.2-apache-onbuild/Dockerfile
@@ -19,8 +19,6 @@ COPY 000-default.conf /etc/apache2/sites-enabled/000-default.conf
 
 RUN chown -R www-data:www-data /var/www/html
 
-# hadolint ignore=DL3002
-USER root
 HEALTHCHECK CMD curl --fail http://localhost/index.php || exit 1
 
 # hadolint ignore=DL3045


### PR DESCRIPTION
This new feature exposes env vars during at build time. 

By convention,  any custom build args should be found in a local script named `artifakt-custom-build-args`, and located on the builder host.

Here is a sample `artifakt-custom-build-args` file:
```bash
export FOO=BAR
export KEY=VAL
```

Building the image only works with BuildKit:

> DOCKER_BUILDKIT=1 docker build -t artifakt-symfony-demo .