### PR TITLE
force ssl for wp

### DIFF
--- a/wordpress/5-apache/Dockerfile
+++ b/wordpress/5-apache/Dockerfile
@@ -4,6 +4,7 @@ LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \
       stage="alpha"
 
+# hadolint ignore=SC2016
 RUN echo 'SetEnv ${HTTPS}' > /etc/apache2/conf-enabled/force-ssl.conf 
 
 # hadolint ignore=DL3045


### PR DESCRIPTION
wordpress needs a specific conf to enable SSL links