### PR TITLE
missing tool in nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,6 +47,7 @@ jobs:
           fetch-depth: 0
       - name: Build Docker Images
         run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && chmod +x container-structure-test-linux-amd64 && sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
           fullDockerfilePath=${{ matrix.dockerfile }}
           folder=${fullDockerfilePath%"/Dockerfile"}
           TMP_IMAGE_ARRAY=($(echo $folder | tr "/" "\n"))


### PR DESCRIPTION
This PR fixes nightly builds, by installing /usr/local/bin/container-structure-test before build script runs.