### PR TITLE
fix nightly & patch upgrade for akeneo5

### DIFF
--- a/akeneo/4-apache/Dockerfile
+++ b/akeneo/4-apache/Dockerfile
@@ -140,7 +140,7 @@ USER root
 
 COPY wait-for-it.sh docker-entrypoint.sh /usr/local/bin/
 COPY akeneo.conf /etc/apache2/sites-available/000-default.conf
-COPY akeneo.ini /usr/local/etc/php/conf.d/
+COPY akeneo.ini /usr/local/etc/php/conf.d/zzzz-akeneo.ini
 
 ENV APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
 ENV APP_DATABASE_NAME=${ARTIFAKT_MYSQL_DATABASE_NAME:-dbname}

--- a/akeneo/5-apache/Dockerfile
+++ b/akeneo/5-apache/Dockerfile
@@ -150,7 +150,7 @@ USER root
 
 COPY wait-for-it.sh docker-entrypoint.sh /usr/local/bin/
 COPY akeneo.conf /etc/apache2/sites-available/000-default.conf
-COPY akeneo.ini /usr/local/etc/php/conf.d/
+COPY akeneo.ini /usr/local/etc/php/conf.d/zzzz-akeneo.ini
 
 ENV APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
 ENV APP_DATABASE_NAME=${ARTIFAKT_MYSQL_DATABASE_NAME:-dbname}


### PR DESCRIPTION
This PR updates base image for akeneo5 to latest stable version in v5 series

It also fixes failing tests, because order matters in PHP ini files. Until we decide on a convention, documentation has been updated with this behavior.
