### PR TITLE
Add missing Akeneo Apache vhost directive

### DIFF
--- a/akeneo/4-apache/akeneo.conf
+++ b/akeneo/4-apache/akeneo.conf
@@ -5,6 +5,7 @@
 
     SetEnv APP_ENV ${APP_ENV}
     SetEnv APP_DEBUG ${APP_DEBUG}
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
     <Directory /var/www/html/pim-community-standard/public>
         AllowOverride None

--- a/akeneo/5-apache/akeneo.conf
+++ b/akeneo/5-apache/akeneo.conf
@@ -5,6 +5,7 @@
 
     SetEnv APP_ENV ${APP_ENV}
     SetEnv APP_DEBUG ${APP_DEBUG}
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
     <Directory /var/www/html/pim-community-standard/public>
         AllowOverride None


### PR DESCRIPTION
Add missing Akeneo Apache vhost directive (see [https://api.akeneo.com/documentation/troubleshooting.html#apache-strip-the-authentication-header](https://api.akeneo.com/documentation/troubleshooting.html#apache-strip-the-authentication-header))