### PR TITLE
escape badge text for shields.io

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,6 @@ jobs:
           TMP_IMAGE_ARRAY=($(echo $folder | tr "/" "\n"))
 
           IMAGE_NAME=${TMP_IMAGE_ARRAY[1]}
-          IMAGE_NAME_ESCAPED=
           TAG=${TMP_IMAGE_ARRAY[2]}
 
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,9 +51,11 @@ jobs:
           TMP_IMAGE_ARRAY=($(echo $folder | tr "/" "\n"))
 
           IMAGE_NAME=${TMP_IMAGE_ARRAY[1]}
+          IMAGE_NAME_ESCAPED=
           TAG=${TMP_IMAGE_ARRAY[2]}
 
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+          echo "IMAGE_NAME_ESCAPED=${IMAGE_NAME/-/--}" >> $GITHUB_ENV
           echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
           echo "DOCKERFILE_FOLDER=$folder" >> $GITHUB_ENV
 
@@ -100,7 +102,7 @@ jobs:
         uses: djalal/job-status-badge@main
         with:
           cloudinary_url: ${{ secrets.CLOUDINARY_URL }}
-          left_text: ${{ env.IMAGE_NAME }}%3A${{ env.IMAGE_TAG }}
+          left_text: ${{ env.IMAGE_NAME_ESCAPED }}%3A${{ env.IMAGE_TAG }}
           right_text: ${{ (startsWith(job.status, 'success') && 'passing') || 'failed' }}
           color: ${{ (startsWith(job.status, 'success') && 'green') || 'red' }}
           public_id: ${{ env.IMAGE_NAME }}_${{ env.IMAGE_TAG }}-status


### PR DESCRIPTION
This PR fixes a use case for shields.io. It needs '-' to be escaped in '--'