### PR TITLE
workaround for akeneo version mgmt

### DIFF
--- a/akeneo/4-apache/Dockerfile
+++ b/akeneo/4-apache/Dockerfile
@@ -4,8 +4,8 @@ LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \
       stage="alpha"
 
-# see release archives https://github.com/akeneo/pim-community-standard/releases
-ARG AKENEO_VERSION=4.0.120
+# see release archives https://github.com/akeneo/pim-community-standard/tags
+ARG AKENEO_VERSION=v4.0.120
 
 # see https://docs.akeneo.com/4.0/install_pim/manual/system_requirements/system_requirements.html
 ARG PHP_EXTENSION_LIST="apcu bcmath gd intl mysqli pdo_mysql zip exif imagick"
@@ -113,10 +113,10 @@ RUN curl -sS https://getcomposer.org/installer | \
 
 WORKDIR /var/www/html
 
-RUN curl -sSLO https://github.com/akeneo/pim-community-standard/archive/v$AKENEO_VERSION.tar.gz && \
-    tar -xzf v$AKENEO_VERSION.tar.gz -C . && \
-    rm v$AKENEO_VERSION.tar.gz && \
-    mv pim-community-standard-$AKENEO_VERSION pim-community-standard && \
+RUN curl -sSLO https://github.com/akeneo/pim-community-standard/archive/$AKENEO_VERSION.tar.gz && \
+    tar -xzf $AKENEO_VERSION.tar.gz -C . && \
+    rm $AKENEO_VERSION.tar.gz && \
+    mv pim-community-standard-"${AKENEO_VERSION:1}" pim-community-standard && \
     chown -R www-data:www-data .
 
 WORKDIR /var/www/html/pim-community-standard


### PR DESCRIPTION
This PR is a small workaround to use full version "vX.Y.Z" instead of only "X.Y.Z" and ease minor upgrades.