### PR TITLE
pin php8 to 8.0

### DIFF
--- a/php/8-apache/Dockerfile
+++ b/php/8-apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-apache
+FROM php:8.0-apache
 
 LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \

--- a/php/8-fpm/Dockerfile
+++ b/php/8-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-fpm
+FROM php:8.0-fpm
 
 LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \


### PR DESCRIPTION
This PR fixes the minor version of php to 8.0, because of some failure with xmlrpc extension in pecl.