### PR TITLE
fix sylius and relax symfony req

### DIFF
--- a/sylius/1.10-apache/test.yaml
+++ b/sylius/1.10-apache/test.yaml
@@ -64,7 +64,7 @@ commandTests:
   - name: "symfony version"
     command: "php"
     args: [ "/var/www/html/bin/console", "--env=prod", "about"]
-    expectedOutput: ['.*Version\s+5\.3\..+']
+    expectedOutput: ['.*Version\s+5\.4\..+']
   - name: "apache version"
     command: "apache2ctl"
     args: [ "-v"]


### PR DESCRIPTION
This PR fixes tests on Sylius 1.10, now using symfony 5.4 instead of 5.3