### PR TITLE
fix mandatory env. var

### DIFF
--- a/sylius/1.11-apache/Dockerfile
+++ b/sylius/1.11-apache/Dockerfile
@@ -24,6 +24,7 @@ RUN export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" 
     && apt-get update && apt-get install --no-install-recommends -y yarn \
     && rm -rf /var/lib/apt/lists/*
 
+ENV MESSENGER_TRANSPORT_DSN="doctrine://default"
 ENV PHP_CONF_MEMORY_LIMIT="-1"
 ENV PHP_CONF_DATE_TIMEZONE="UTC"
 ENV PHP_CONF_MAX_EXECUTION_TIME=600


### PR DESCRIPTION
This PR fixes a mandatory env. var with default value. for Sylius 1.11