### PR TITLE
sylius should not share cache between containers

### DIFF
--- a/sylius/1.11-apache/docker-entrypoint.sh
+++ b/sylius/1.11-apache/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-PERSISTENT_FOLDER_LIST=("var/cache" "var/sessions" "public/media" "public/uploads" "config/jwt")
+PERSISTENT_FOLDER_LIST=("var/sessions" "public/media" "public/uploads" "config/jwt")
 
 for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
   echo Mount $persistent_folder directory


### PR DESCRIPTION
This PR fixes a case of cache confusion between containers of same service. Sharing the same cache volume between containers does not work, so we will disable it for now, until we find a more cloud native solution.