### PR TITLE
restore upstream patch version for php 8.0.x

### DIFF
--- a/php/8-apache/Dockerfile
+++ b/php/8-apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.14-apache
+FROM php:8.0-apache
 
 LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \

--- a/php/8-fpm/Dockerfile
+++ b/php/8-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.14-fpm
+FROM php:8.0-fpm
 
 LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \


### PR DESCRIPTION
This PR restores the default tracking of patch version for php 8.0.x after the regression on 8.0.15