### PR TITLE
backport mutext on entrypoint with database initialization

### DIFF
--- a/akeneo/4-apache/docker-entrypoint.sh
+++ b/akeneo/4-apache/docker-entrypoint.sh
@@ -17,8 +17,29 @@ rm -rf /var/www/html/pim-community-standard/var/logs && \
   ln -sfn /var/log/artifakt /var/www/html/pim-community-standard/var/logs && \
   chown -h www-data:www-data /var/www/html/pim-community-standard/var/logs /var/log/artifakt
 
-if [ -x "/.artifakt/entrypoint.sh" ]; then
-    source /.artifakt/entrypoint.sh
+if [[ -x "/.artifakt/entrypoint.sh" ]]; then
+
+  # source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+  function lock_cmd {
+      LOCK_FILE="$1"; shift
+      LOCK_TIMEOUT="$1"; shift;
+
+      (
+          trap "rm -f $LOCK_FILE" 0
+          flock -x -w $LOCK_TIMEOUT 200
+          RETVAL=$?
+          if [ $RETVAL -ne 0 ]; then
+              echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+              exit $RETVAL
+          fi
+          echo -e "Running command: $@"
+          $@
+      ) 200>"$LOCK_FILE"
+  }
+
+  lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+  lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+  lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 su www-data -s /bin/sh -c './bin/console pim:installer:check-requirements'

--- a/akeneo/5-apache/docker-entrypoint.sh
+++ b/akeneo/5-apache/docker-entrypoint.sh
@@ -17,8 +17,29 @@ rm -rf /var/www/html/pim-community-standard/var/logs && \
   ln -sfn /var/log/artifakt /var/www/html/pim-community-standard/var/logs && \
   chown -h www-data:www-data /var/www/html/pim-community-standard/var/logs /var/log/artifakt
 
-if [ -x "/.artifakt/entrypoint.sh" ]; then
-    source /.artifakt/entrypoint.sh
+if [[ -x "/.artifakt/entrypoint.sh" ]]; then
+
+  # source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+  function lock_cmd {
+      LOCK_FILE="$1"; shift
+      LOCK_TIMEOUT="$1"; shift;
+
+      (
+          trap "rm -f $LOCK_FILE" 0
+          flock -x -w $LOCK_TIMEOUT 200
+          RETVAL=$?
+          if [ $RETVAL -ne 0 ]; then
+              echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+              exit $RETVAL
+          fi
+          echo -e "Running command: $@"
+          $@
+      ) 200>"$LOCK_FILE"
+  }
+
+  lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+  lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+  lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 su www-data -s /bin/sh -c './bin/console pim:installer:check-requirements'

--- a/drupal/9.2-apache/docker-entrypoint.sh
+++ b/drupal/9.2-apache/docker-entrypoint.sh
@@ -12,7 +12,28 @@ for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
 done
 
 if [[ -x "/.artifakt/entrypoint.sh" ]]; then
-    source /.artifakt/entrypoint.sh
+
+  # source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+  function lock_cmd {
+      LOCK_FILE="$1"; shift
+      LOCK_TIMEOUT="$1"; shift;
+
+      (
+          trap "rm -f $LOCK_FILE" 0
+          flock -x -w $LOCK_TIMEOUT 200
+          RETVAL=$?
+          if [ $RETVAL -ne 0 ]; then
+              echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+              exit $RETVAL
+          fi
+          echo -e "Running command: $@"
+          $@
+      ) 200>"$LOCK_FILE"
+  }
+
+  lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+  lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+  lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 # inject dotenv conf file

--- a/shopware/6.4-apache/docker-entrypoint.sh
+++ b/shopware/6.4-apache/docker-entrypoint.sh
@@ -27,7 +27,28 @@ rm -rf /var/www/html/var/logs && \
 ln -snf /data/.uniqueid.txt /var/www/html/
 
 if [[ -x "/.artifakt/entrypoint.sh" ]]; then
-    source /.artifakt/entrypoint.sh
+
+  # source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+  function lock_cmd {
+      LOCK_FILE="$1"; shift
+      LOCK_TIMEOUT="$1"; shift;
+
+      (
+          trap "rm -f $LOCK_FILE" 0
+          flock -x -w $LOCK_TIMEOUT 200
+          RETVAL=$?
+          if [ $RETVAL -ne 0 ]; then
+              echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+              exit $RETVAL
+          fi
+          echo -e "Running command: $@"
+          $@
+      ) 200>"$LOCK_FILE"
+  }
+
+  lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+  lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+  lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 # first arg is `-f` or `--some-option`

--- a/sylius/1.10-apache/docker-entrypoint.sh
+++ b/sylius/1.10-apache/docker-entrypoint.sh
@@ -27,8 +27,29 @@ if [[ ! -f /data/passphrase ]]; then
 fi
 source /data/passphrase
 
-if [ -x "/.artifakt/entrypoint.sh" ]; then
-    source /.artifakt/entrypoint.sh
+if [[ -x "/.artifakt/entrypoint.sh" ]]; then
+
+  # source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+  function lock_cmd {
+      LOCK_FILE="$1"; shift
+      LOCK_TIMEOUT="$1"; shift;
+
+      (
+          trap "rm -f $LOCK_FILE" 0
+          flock -x -w $LOCK_TIMEOUT 200
+          RETVAL=$?
+          if [ $RETVAL -ne 0 ]; then
+              echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+              exit $RETVAL
+          fi
+          echo -e "Running command: $@"
+          $@
+      ) 200>"$LOCK_FILE"
+  }
+
+  lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+  lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+  lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 su www-data -s /bin/sh -c 'php bin/console sylius:install:check-requirements'

--- a/sylius/1.11-apache/docker-entrypoint.sh
+++ b/sylius/1.11-apache/docker-entrypoint.sh
@@ -25,10 +25,32 @@ if [[ ! -f /data/passphrase ]]; then
   echo export JWT_PASSPHRASE=$key >> /data/passphrase
   chown www-data:www-data /data/passphrase
 fi
+
 source /data/passphrase
 
-if [ -x "/.artifakt/entrypoint.sh" ]; then
-    source /.artifakt/entrypoint.sh
+if [[ -x "/.artifakt/entrypoint.sh" ]]; then
+
+  # source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+  function lock_cmd {
+      LOCK_FILE="$1"; shift
+      LOCK_TIMEOUT="$1"; shift;
+
+      (
+          trap "rm -f $LOCK_FILE" 0
+          flock -x -w $LOCK_TIMEOUT 200
+          RETVAL=$?
+          if [ $RETVAL -ne 0 ]; then
+              echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+              exit $RETVAL
+          fi
+          echo -e "Running command: $@"
+          $@
+      ) 200>"$LOCK_FILE"
+  }
+
+  lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+  lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+  lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 su www-data -s /bin/sh -c 'php bin/console sylius:install:check-requirements'

--- a/symfony/4.4-apache/docker-entrypoint.sh
+++ b/symfony/4.4-apache/docker-entrypoint.sh
@@ -20,7 +20,28 @@ fi
 source /data/secret-key
 
 if [[ -x "/.artifakt/entrypoint.sh" ]]; then
-    source /.artifakt/entrypoint.sh
+
+	# source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+	function lock_cmd {
+	    LOCK_FILE="$1"; shift
+	    LOCK_TIMEOUT="$1"; shift;
+
+	    (
+	        trap "rm -f $LOCK_FILE" 0
+	        flock -x -w $LOCK_TIMEOUT 200
+	        RETVAL=$?
+	        if [ $RETVAL -ne 0 ]; then
+	            echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+	            exit $RETVAL
+	        fi
+	        echo -e "Running command: $@"
+	        $@
+	    ) 200>"$LOCK_FILE"
+	}
+
+	lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+	lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+	lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 # first arg is `-f` or `--some-option`

--- a/symfony/5.3-apache/docker-entrypoint.sh
+++ b/symfony/5.3-apache/docker-entrypoint.sh
@@ -20,7 +20,28 @@ fi
 source /data/secret-key
 
 if [[ -x "/.artifakt/entrypoint.sh" ]]; then
-    source /.artifakt/entrypoint.sh
+
+	# source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+	function lock_cmd {
+	    LOCK_FILE="$1"; shift
+	    LOCK_TIMEOUT="$1"; shift;
+
+	    (
+	        trap "rm -f $LOCK_FILE" 0
+	        flock -x -w $LOCK_TIMEOUT 200
+	        RETVAL=$?
+	        if [ $RETVAL -ne 0 ]; then
+	            echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+	            exit $RETVAL
+	        fi
+	        echo -e "Running command: $@"
+	        $@
+	    ) 200>"$LOCK_FILE"
+	}
+
+	lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+	lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+	lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 # first arg is `-f` or `--some-option`

--- a/wordpress/5-apache/docker-entrypoint.sh
+++ b/wordpress/5-apache/docker-entrypoint.sh
@@ -12,7 +12,28 @@ for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
 done
 
 if [[ -x "/.artifakt/entrypoint.sh" ]]; then
-    source /.artifakt/entrypoint.sh
+
+	# source: https://gist.github.com/karlrwjohnson/1921b05c290edb665c238676ef847f3c
+	function lock_cmd {
+	    LOCK_FILE="$1"; shift
+	    LOCK_TIMEOUT="$1"; shift;
+
+	    (
+	        trap "rm -f $LOCK_FILE" 0
+	        flock -x -w $LOCK_TIMEOUT 200
+	        RETVAL=$?
+	        if [ $RETVAL -ne 0 ]; then
+	            echo -e "Failed to aquire lock on $LOCK_FILE within $LOCK_TIMEOUT seconds. Is a similar script hung?"
+	            exit $RETVAL
+	        fi
+	        echo -e "Running command: $@"
+	        $@
+	    ) 200>"$LOCK_FILE"
+	}
+
+	lock_file=${ARTIFAKT_ENTRYPOINT_LOCK:-/data/artifakt-entrypoint-lock}
+	lock_timeout=${ARTIFAKT_TIMEOUT_LOCK:-600}
+	lock_cmd $lock_file $lock_timeout /.artifakt/entrypoint.sh
 fi
 
 # first arg is `-f` or `--some-option`


### PR DESCRIPTION
This PR introduces a mutex mechanism on container initialisation. In case the platform is running many containers at once from the same Docker image, any database initialization must origin from one container only.

The updated runtimes are known to require databases by default, but if the need arises in the community, and depending on feedback, we could propagate the same mutex to other low level runtimes, like languages. 