### PR TITLE
restore upstream for sf4.4

### DIFF
--- a/symfony/4.4-apache/Dockerfile
+++ b/symfony/4.4-apache/Dockerfile
@@ -1,6 +1,37 @@
-FROM registry.artifakt.io/symfony:4.4-apache@sha256:16d38d8d7892f9f31fef0d0804efd732c31ff61a723bc0f8c3cf2a81566f1dbf
+FROM registry.artifakt.io/php:7.4-apache
 
 LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \
       stage="alpha"
+
+ARG COMPOSER_VERSION=2.1.3
+ARG SYMFONY4_VERSION=4.4
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -sS https://getcomposer.org/installer | \
+  php -- --version=${COMPOSER_VERSION} --install-dir=/usr/local/bin --filename=composer
+
+USER www-data
+RUN composer --no-cache create-project symfony/website-skeleton:"^${SYMFONY4_VERSION}" /tmp/website-skeleton && \
+    rm -rf /var/www/html/{.[!.],}* && \
+    mv /tmp/website-skeleton/{.[!.],}* /var/www/html
+WORKDIR /var/www/html
+RUN composer require symfony/apache-pack
+
+# hadolint ignore=DL3002
+USER root
+
+COPY 000-default.conf /etc/apache2/sites-available/
+RUN a2enmod rewrite && a2ensite 000-default
+
+# Create the parameter.yml file if it doesn't exist
+COPY --chown=www-data:www-data etc/parameters.yml /var/www/html/config/parameters.yml
+
+HEALTHCHECK CMD curl --fail http://localhost/index.php || exit 1
+
+# hadolint ignore=DL3045
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]
 


### PR DESCRIPTION
This PR puts back the upstream link with official vendor for Symfony 4.4. Build is now fixed and we should restore it to benefit from fixes.