### PR TITLE
(fix) data init on php8fpm

### DIFF
--- a/php/8-fpm/docker-entrypoint.sh
+++ b/php/8-fpm/docker-entrypoint.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
+
 set -e
 
-PERSISTENT_FOLDER_LIST=("/")
+echo Copy modified/new files from container /var/www/html to volume /data
+cp -ur /var/www/html/* /data || true
 
-for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
-  echo Copy modified/new files from container (/var/www/html/$persistent_folder ) to volume (/data/$persistent_folder)
-  cp -ur /var/www/html/$persistent_folder /data/$persistent_folder
-
-  echo Link /data/$persistent_folder directory to /var/www/html/$persistent_folder
-  rm -rf /var/www/html/$persistent_folder && \
-    mkdir -p /data/$persistent_folder && \
-    ln -sfn /data/$persistent_folder /var/www/html/$persistent_folder && \
-    chown -h www-data:www-data /var/www/html/$persistent_folder /data/$persistent_folder
-done
+echo Link /data directory to /var/www/html
+rm -rf /var/www/html && \
+  mkdir -p /data && \
+  mkdir -p /var/www && \
+  ln -sfn /data /var/www/html && \
+  chown -h -R -L www-data:www-data /var/www/html /data
 
 if [[ -x "/.artifakt/entrypoint.sh" ]]; then
     source /.artifakt/entrypoint.sh
@@ -20,7 +18,7 @@ fi
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-	set -- php-fpm "$@"
+  set -- php-fpm "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This PR fixes data initialization on php8 FPM. The shared volume should be populated with data from container at the first run. In PHP8, by default, we copy the whole /var/www/html to share assets with nginx.