### PR TITLE
prepare php74 eol

### DIFF
--- a/sylius/1.10-apache/Dockerfile
+++ b/sylius/1.10-apache/Dockerfile
@@ -23,6 +23,7 @@ RUN export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" 
     && apt-get update && apt-get install --no-install-recommends -y yarn \
     && rm -rf /var/lib/apt/lists/*
 
+ENV MESSENGER_TRANSPORT_DSN="doctrine://default"
 ENV PHP_CONF_MEMORY_LIMIT="-1"
 ENV PHP_CONF_DATE_TIMEZONE="UTC"
 ENV PHP_CONF_MAX_EXECUTION_TIME=600

--- a/sylius/1.10-apache/Dockerfile
+++ b/sylius/1.10-apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.artifakt.io/php:7.4-apache
+FROM registry.artifakt.io/php:8-apache
 
 LABEL vendor="Artifakt" \
       author="djalal@artifakt.io" \

--- a/sylius/1.10-apache/test.yaml
+++ b/sylius/1.10-apache/test.yaml
@@ -76,7 +76,7 @@ commandTests:
   - name: "php version"
     command: "php"
     args: [ "-r", "echo phpversion();"]
-    expectedOutput: ['.*7\.4\.*']
+    expectedOutput: ['.*8\.0\.*']
   - name: "php timezone = UTC"
     command: "php"
     args: [ "-r", "echo ini_get('date.timezone');"]


### PR DESCRIPTION
This PR moves Sylius 1.10 to php8 by default, to prepare for php7.4 EOL