### PR TITLE
increase memory limit for composer in symfony 4.4

### DIFF
--- a/symfony/4.4-apache/Dockerfile
+++ b/symfony/4.4-apache/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sS https://getcomposer.org/installer | \
   php -- --version=${COMPOSER_VERSION} --install-dir=/usr/local/bin --filename=composer
 
 USER www-data
-RUN composer --no-cache create-project symfony/website-skeleton:"^${SYMFONY4_VERSION}" /tmp/website-skeleton && \
+RUN COMPOSER_MEMORY_LIMIT=-1 composer --no-cache create-project symfony/website-skeleton:"^${SYMFONY4_VERSION}" /tmp/website-skeleton && \
     rm -rf /var/www/html/{.[!.],}* && \
     mv /tmp/website-skeleton/{.[!.],}* /var/www/html
 WORKDIR /var/www/html


### PR DESCRIPTION
This PR fixes the "out of memory" error during SF4.4 builds.