### PR TITLE
Upgrade Akeneo5 from node12 to node14

### DIFF
--- a/akeneo/5-apache/Dockerfile
+++ b/akeneo/5-apache/Dockerfile
@@ -15,7 +15,7 @@ ARG COMPOSER_VERSION=2.1.3
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -fsSL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*

--- a/akeneo/5-apache/test.yaml
+++ b/akeneo/5-apache/test.yaml
@@ -58,7 +58,7 @@ commandTests:
   - name: "nodejs version"
     command: "node"
     args: [ "-v"]
-    expectedOutput: ['v12\..+']
+    expectedOutput: ['v14\..+']
   - name: "yarn version"
     command: "yarn"
     args: [ "-v"]


### PR DESCRIPTION
This PR upgrades node in Akeneo from v12 to v14 (current LTS)