### PR TITLE
update npm expected output npm from 8.18.* to 8.19.*

### DIFF
--- a/node/18/test.yaml
+++ b/node/18/test.yaml
@@ -55,7 +55,7 @@ commandTests:
   - name: "npm version"
     command: "npm"
     args: [ "--version"]
-    expectedOutput: ['8\.18\.*']
+    expectedOutput: ['8\.19\.*']
 
   - name: "yarn version"
     command: "yarn"


### PR DESCRIPTION
the expectedOutput throw an error cause of deprecated version. I've change it to 8.19.* to fix it.