### PR TITLE
Missing custom_media conf include

### DIFF
--- a/magento/2.4/artifakt_templates/nginx/default.conf
+++ b/magento/2.4/artifakt_templates/nginx/default.conf
@@ -200,6 +200,9 @@ server {
     }
 
     location /media/ {
+        
+        include /etc/nginx/conf.d/custom_media.conf;
+        
         try_files $uri $uri/ /get.php$is_args$args;
 
         location ~ ^/media/theme_customization/.*\.xml {


### PR DESCRIPTION
According to https://docs.artifakt.com/production-guide/magento-2.4/nginx-configuration