### PR TITLE
[magento](nginx): move custom_server.conf inclusion

### DIFF
--- a/magento/2.4/artifakt_templates/nginx/default.conf
+++ b/magento/2.4/artifakt_templates/nginx/default.conf
@@ -288,12 +288,12 @@ server {
         image/svg+xml;
     gzip_vary on;
 
+   include /etc/nginx/conf.d/custom_server.conf;
+
     # Banned locations (only reached if the earlier PHP entry point regexes don't match)
     location ~* (\.php$|\.phtml$|\.htaccess$|\.git) {
         deny all;
     }
-
-    include /etc/nginx/conf.d/custom_server.conf;
 
 }
 


### PR DESCRIPTION
Move custom_server.conf inclusion on nginx/default.conf in order to authorize new locations with php files