### PR TITLE
[Magento] Update missing custom_global.conf

### DIFF
--- a/magento/2.4-php8/artifakt_templates/nginx/default.conf
+++ b/magento/2.4-php8/artifakt_templates/nginx/default.conf
@@ -2,6 +2,8 @@
 user nginx;
 worker_processes  auto;
 
+include /etc/nginx/conf.d/custom_global.conf;
+
 error_log  /var/log/nginx/error.log error;
 pid        /var/run/nginx.pid;
 

--- a/magento/2.4/artifakt_templates/nginx/default.conf
+++ b/magento/2.4/artifakt_templates/nginx/default.conf
@@ -2,6 +2,8 @@
 user nginx;
 worker_processes  auto;
 
+include /etc/nginx/conf.d/custom_global.conf;
+
 error_log  /var/log/nginx/error.log error;
 pid        /var/run/nginx.pid;
 


### PR DESCRIPTION
The custom_global.conf is missing in the default ngix conf.
So if we want to add a module for example 

```
#loadModule Resize Image
load_module /usr/lib/nginx/modules/ngx_http_image_filter_module.so;
```

and use it in out custom_media.conf, nginx will throw an error like

nginx: [emerg] unknown directive "image_filter" in /etc/nginx/conf.d/custom_media.conf:19

This PR fix this issue and was related to #749