### PR TITLE
Update nginx static expire max

### DIFF
--- a/magento/2.4-php8/artifakt_templates/nginx/default.conf
+++ b/magento/2.4-php8/artifakt_templates/nginx/default.conf
@@ -171,7 +171,7 @@ server {
 
     location /static/ {
         # Uncomment the following line in production mode
-        # expires max;
+        expires max;
 
         # Remove signature of the static files that is used to overcome the browser cache
         location ~ ^/static/version[a-z0-9]*/ {

--- a/magento/2.4/artifakt_templates/nginx/default.conf
+++ b/magento/2.4/artifakt_templates/nginx/default.conf
@@ -170,7 +170,7 @@ server {
 
     location /static/ {
         # Uncomment the following line in production mode
-        # expires max;
+        expires max;
 
         # Remove signature of the static files that is used to overcome the browser cache
         location ~ ^/static/version[a-z0-9]*/ {


### PR DESCRIPTION
According to magento recommendation
https://github.com/magento/magento2/blob/2.4.5-p1/nginx.conf.sample#L27

in production mode as defined here  https://github.com/artifakt-io/artifakt-docker-images/blob/main/magento/2.4/artifakt_templates/nginx/default.conf#L74 

tIn production mode, you should uncomment the 'expires' directive in the /static/ location block
